### PR TITLE
Add Docker build and push CI/CD workflow configurations for use by GitHub Actions

### DIFF
--- a/.github/workflows/workflow-docker.yaml
+++ b/.github/workflows/workflow-docker.yaml
@@ -21,11 +21,6 @@ on:
     #  │ │ │ │ │
     #  * * * * *
     - cron: "0 20 * * THU"
-  #
-  # COMMENT OUT PUSH TRIGGER BELOW WHEN DONE TESTING
-  push:
-    branches:
-      - "dev-docker**"
 
 jobs:
   run-workflow:

--- a/.github/workflows/workflow-docker.yaml
+++ b/.github/workflows/workflow-docker.yaml
@@ -4,6 +4,13 @@ name: Run CI/CD Docker Workflow
 
 on:
   workflow_dispatch:
+  #
+  # Should be run on a cron schedule every Thursday night, prior to the weekly workflow.
+  #
+  # Does not need to run on a repo-specific event (e.g., "push" or PR), since the latest
+  # versions of all other rcsb.* packages are downloaded anyway (so, not dependent on any
+  # single package in particular).
+  #
   schedule:
     # Time is based on UTC timezone
     #  ┌───────────── minute (0 - 59)
@@ -13,7 +20,6 @@ on:
     #  │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #  │ │ │ │ │
     #  * * * * *
-    # * is a special character in YAML so you have to quote this string
     - cron: "0 20 * * THU"
   #
   # COMMENT OUT PUSH TRIGGER BELOW WHEN DONE TESTING
@@ -27,10 +33,6 @@ jobs:
     uses: rcsb/devops-cicd-github-actions/.github/workflows/workflow-docker.yaml@master
     with:
       dockerfile_location: "Dockerfile"  # The location of the Dockerfile relative to the root of the repository. Defaults to "Dockerfile".
-      repo_project: "devops"  # REQUIRED. The name of the project or organization in the remote Docker image repository.
+      repo_project: "rcsb"  # REQUIRED. The name of the project or organization in the remote Docker image repository.
       docker_image_name: "rcsb-exdb"  # REQUIRED. The name of the Docker image to create.
       docker_build_context: "."  # The path location of the docker build context, relative to the project root. Defaults to the project root.
-      # repo_url: # The URL of the remote Docker image repository. Defaults to "harbor.devops.k8s.rcsb.org".
-      # mainline_branch: # The mainline branch for the repo. Deployments to the staging and production environments are done only on push to this branch. Defaults to master.    
-      # do_staging_build: # Build, tag, and push a docker image with the staging tag.
-      # do_production_build: # Build, tag, and push a docker image with the production tag.

--- a/.github/workflows/workflow-docker.yaml
+++ b/.github/workflows/workflow-docker.yaml
@@ -1,0 +1,36 @@
+# Docker build and push workflow
+
+name: Run CI/CD Docker Workflow
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Time is based on UTC timezone
+    #  ┌───────────── minute (0 - 59)
+    #  │ ┌───────────── hour (0 - 23)
+    #  │ │ ┌───────────── day of the month (1 - 31)
+    #  │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #  │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #  │ │ │ │ │
+    #  * * * * *
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 20 * * THU"
+  #
+  # COMMENT OUT PUSH TRIGGER BELOW WHEN DONE TESTING
+  push:
+    branches:
+      - "dev-docker**"
+
+jobs:
+  run-workflow:
+    name: "Run automated docker workflow"
+    uses: rcsb/devops-cicd-github-actions/.github/workflows/workflow-docker.yaml@master
+    with:
+      dockerfile_location: "Dockerfile"  # The location of the Dockerfile relative to the root of the repository. Defaults to "Dockerfile".
+      repo_project: "devops"  # REQUIRED. The name of the project or organization in the remote Docker image repository.
+      docker_image_name: "rcsb-exdb"  # REQUIRED. The name of the Docker image to create.
+      docker_build_context: "."  # The path location of the docker build context, relative to the project root. Defaults to the project root.
+      # repo_url: # The URL of the remote Docker image repository. Defaults to "harbor.devops.k8s.rcsb.org".
+      # mainline_branch: # The mainline branch for the repo. Deployments to the staging and production environments are done only on push to this branch. Defaults to master.    
+      # do_staging_build: # Build, tag, and push a docker image with the staging tag.
+      # do_production_build: # Build, tag, and push a docker image with the production tag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,6 @@ RUN apt-get update \
 RUN pip install --no-cache-dir --upgrade "pip>=23.0.0" "setuptools>=40.8.0" "wheel>=0.43.0" \
     && pip install --no-cache-dir --user -r /app/requirements.txt \
     && pip install --no-cache-dir pymongo==3.12.0
+
+# Install the latest version of THIS packages
+RUN pip install --no-cache-dir "rcsb.exdb>=1.21"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update \
     && apt-get install -y build-essential=12.* pkg-config=1.8.* default-libmysqlclient-dev=1.1.*
 
 # Install the required Python packages
-RUN pip install --no-cache-dir --user -r /app/requirements.txt \
+RUN pip install --no-cache-dir --upgrade "pip>=23.0.0" "setuptools>=40.8.0" "wheel>=0.43.0" \
+    && pip install --no-cache-dir --user -r /app/requirements.txt \
     && pip install --no-cache-dir pymongo==3.12.0
-# pip install --no-cache-dir --upgrade pip setuptools wheel \
 
 # Specify the command to run on container start
 # CMD ["python", "script.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for building image with all ExDB CLI commands 
+# and packages needed for running ETL workflow
+
+# Use an official Python image as a base image
+FROM python:3.9-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# copy requirements file (should include selected versions of uvicorn gunicorn)
+COPY ./requirements.txt /app/requirements.txt
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y build-essential pkg-config default-libmysqlclient-dev
+
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir --user -r /app/requirements.txt \
+    && pip install --no-cache-dir rcsb.workflow rcsb.utils.io pymongo
+
+# Install the required Python packages
+# RUN pip install --no-cache-dir rcsb.db rcsb.exdb
+
+# Specify the command to run on container start
+# CMD ["python", "script.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update \
     && apt-get install -y build-essential=12.* pkg-config=1.8.* default-libmysqlclient-dev=1.1.*
 
 # Install the required Python packages
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir --user -r /app/requirements.txt \
+RUN pip install --no-cache-dir --user -r /app/requirements.txt \
     && pip install --no-cache-dir pymongo==3.12.0
+# pip install --no-cache-dir --upgrade pip setuptools wheel \
 
 # Specify the command to run on container start
 # CMD ["python", "script.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,10 @@ COPY ./requirements.txt /app/requirements.txt
 # Install system dependencies
 RUN apt-get update \
     # Confirmed versions that work: build-essential=12.9 pkg-config=1.8.1-1 default-libmysqlclient-dev=1.1.0
-    && apt-get install -y build-essential=12.* pkg-config=1.8.* default-libmysqlclient-dev=1.1.*
+    && apt-get install -y --no-install-recommends build-essential=12.* pkg-config=1.8.* default-libmysqlclient-dev=1.1.* \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install the required Python packages
 RUN pip install --no-cache-dir --upgrade "pip>=23.0.0" "setuptools>=40.8.0" "wheel>=0.43.0" \
     && pip install --no-cache-dir --user -r /app/requirements.txt \
     && pip install --no-cache-dir pymongo==3.12.0
-
-# Specify the command to run on container start
-# CMD ["python", "script.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,18 @@ FROM python:3.9-slim
 # Set the working directory inside the container
 WORKDIR /app
 
-# copy requirements file (should include selected versions of uvicorn gunicorn)
+# Copy requirements file
 COPY ./requirements.txt /app/requirements.txt
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get install -y build-essential pkg-config default-libmysqlclient-dev
-
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir --user -r /app/requirements.txt \
-    && pip install --no-cache-dir rcsb.workflow rcsb.utils.io pymongo
+    # Confirmed versions that work: build-essential=12.9 pkg-config=1.8.1-1 default-libmysqlclient-dev=1.1.0
+    && apt-get install -y build-essential=12.* pkg-config=1.8.* default-libmysqlclient-dev=1.1.*
 
 # Install the required Python packages
-# RUN pip install --no-cache-dir rcsb.db rcsb.exdb
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir --user -r /app/requirements.txt \
+    && pip install --no-cache-dir pymongo==3.12.0
 
 # Specify the command to run on container start
 # CMD ["python", "script.py"]


### PR DESCRIPTION
[RO-4305](https://rcsbpdb.atlassian.net/browse/RO-4305): We need an automated CI/CD pipeline to create docker images for ExDB pipeline. Docker images should be pushed to Harbor, our internal docker repository.