### PR TITLE
Fix: V1.36 Update GlycanUtils to use built-in requests and new GlyTouCan API URL

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -117,3 +117,4 @@
  6-Jan-2026 V1.33 Updates to TreeNodeListWorker to raise errors upon failures and allow for manual specification of tree lists to load
  2-Feb-2026 V1.34 Handle case of missing 'rcsb_entity_source_organism.source_type' in PolymerEntityExtractor
  7-May-2026 V1.35 Update EntryInfoEtlWorkflow to not stash data file if empty
+ 8-Jun-2026 V1.36 Update GlycanUtils to use built-in requests and new GlyTouCan API URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rcsb.exdb"
 description = "RCSB Python ExDB data extraction and loading workflows"
-version = "1.35"
+version = "1.36"
 readme = "README.md"
 authors = [
     { name="John Westbrook", email="john.westbrook@rcsb.org" }

--- a/rcsb/exdb/branch/GlycanUtils.py
+++ b/rcsb/exdb/branch/GlycanUtils.py
@@ -2,18 +2,20 @@
 #  File:           GlycanUtils.py
 #  Date:           24-May-2021 jdw
 #
-#  Updated:
+# Updates:
+#  8-Jun-2026 dwp Switch to using built-in requests library; update GlyTouCan API URL
 ##
 """
 Utilities for fetching and mapping glycan accessions.
 """
 
+import time
 import logging
 import os.path
+import requests
 
 from rcsb.exdb.branch.BranchedEntityExtractor import BranchedEntityExtractor
 from rcsb.utils.io.MarshalUtil import MarshalUtil
-from rcsb.utils.io.UrlRequestUtil import UrlRequestUtil
 
 logger = logging.getLogger(__name__)
 
@@ -88,18 +90,66 @@ class GlycanUtils:
         return entityAccessionMapD
 
     def getAccessionMapping(self, wurcsTupL):
-        """Fetch GlyTouCan accessions for the input WURCS desriptor list"""
+        """Fetch GlyTouCan accessions for the input WURCS descriptor list.
+        Retries on timeouts, connection errors, and HTTP 5XX responses, while immediately failing on 4XX responses.
+
+        Example:
+          curl -d wurcs='WURCS=2.0/1,2,1/[a2122h-1a_1-5]/1-1/a4-b1' https://api.glycosmos.org/sparqlist/wurcs2gtcids
+
+        Docs: https://doc.glycosmos.org/api/glytoucan
+        """
         accessionMapD = {}
-        logger.info("Fetching (%d) WURCS descriptors", len(wurcsTupL))
-        baseUrl = "https://api.glycosmos.org"
-        endPoint = "glytoucan/sparql/wurcs2gtcids"
         numDescriptors = len(wurcsTupL)
+        logger.info("Fetching (%d) WURCS descriptors", numDescriptors)
+        url = "https://api.glycosmos.org/sparqlist/wurcs2gtcids"
+
         for ii, (entityId, wurcs) in enumerate(wurcsTupL, 1):
             try:
-                pD = {}
-                pD["wurcs"] = wurcs
-                uR = UrlRequestUtil()
-                rDL, retCode = uR.post(baseUrl, endPoint, pD, returnContentType="JSON")
+                maxRetries = 3
+                for attempt in range(maxRetries):
+                    try:
+                        response = requests.post(url, data={"wurcs": wurcs}, timeout=30)
+                        retCode = response.status_code
+
+                        if 500 <= retCode < 600:
+                            raise requests.HTTPError(f"Server error ({retCode})", response=response)
+
+                        response.raise_for_status()
+                        rDL = response.json()
+                        break
+
+                    except (requests.Timeout, requests.ConnectionError) as e:
+                        if attempt == maxRetries - 1:
+                            raise
+                        waitTime = 2 ** attempt
+                        logger.warning(
+                            "Retry %d/%d for entityId %r after %d second(s) due to %s",
+                            attempt + 1,
+                            maxRetries,
+                            entityId,
+                            waitTime,
+                            str(e),
+                        )
+                        time.sleep(waitTime)
+
+                    except requests.HTTPError as e:
+                        if e.response is not None and 400 <= e.response.status_code < 500:
+                            raise
+
+                        if attempt == maxRetries - 1:
+                            raise
+
+                        waitTime = 2 ** attempt
+                        logger.warning(
+                            "Retry %d/%d for entityId %r after %d second(s) due to HTTP %d",
+                            attempt + 1,
+                            maxRetries,
+                            entityId,
+                            waitTime,
+                            retCode,
+                        )
+                        time.sleep(waitTime)
+
                 logger.debug(" %r wurcs fetch result (%r) %r", entityId, retCode, rDL)
                 if rDL:
                     for rD in rDL:
@@ -107,8 +157,13 @@ class GlycanUtils:
                             accessionMapD.setdefault(wurcs, []).append(rD["id"])
                         else:
                             logger.info("%r fetch fails (%r) (%r) %r", entityId, retCode, wurcs, rDL)
+                else:
+                    logger.info("No results returned (%r) for entityId %r wurcs '%r'", retCode, entityId, wurcs)
+
                 if ii % 5 == 0:
                     logger.info("Fetched %d/%d", ii, numDescriptors)
-            except Exception as e:
+
+            except requests.RequestException as e:
                 logger.exception("Failing for (%r) wurcs (%r) with %s", entityId, wurcs, str(e))
+
         return accessionMapD


### PR DESCRIPTION
The previous use of `UrlRequestUtil.post()` to query GlyTouCan stopped working recently, in which it started returning 403. This was due to a combination of two issues with the [`UrlRequestUtil.post()`](https://github.com/rcsb/py-rcsb_utils_io/blob/49c6ad68266b8cab572408bebe57040fcff88cc7/rcsb/utils/io/UrlRequestUtil.py#L71) method—first that the User-Agent "Python-urllib*" appears to be blocked (which is the default), and second there appears to be another underlying issue with the request implementation.

This PR replaces the use of `UrlRequestUtil` with the built-in `requests` library. 

In the long-term, we should plan to update [`UrlRequestUtil.py`](https://github.com/rcsb/py-rcsb_utils_io/blob/49c6ad68266b8cab572408bebe57040fcff88cc7/rcsb/utils/io/UrlRequestUtil.py) directly to use the `requests` library instead of `urllib`.